### PR TITLE
Adding the log collector script

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -45,10 +45,11 @@ RUN apt-get update && \
     mv /usr/sbin/traceroute /usr/bin/traceroute && \
     curl -sLf https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
+    curl -sLf https://raw.githubusercontent.com/rancherlabs/support-tools/master/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh > /usr/local/bin/rancher2_logs_collector.sh && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.16.8/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.16 && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.17.4/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.17 && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.18 && \
-    chmod +x /usr/local/bin/kubectl* && \
+    chmod +x /usr/local/bin/* && \
     ln -s /usr/local/bin/kubectl-1.18 /usr/local/bin/kubectl && \
     mkdir /root/.kube
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -46,12 +46,12 @@ RUN apt-get update && \
     curl -sLf https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
     curl -sLf https://raw.githubusercontent.com/rancherlabs/support-tools/master/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh > /usr/local/bin/rancher2_logs_collector.sh && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.16.8/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.16 && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.17.4/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.17 && \
-    curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.18 && \
+    curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.16.15/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.16 && \
+    curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.17 && \
+    curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.18.17/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.18 && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.19.8/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.19 && \
     curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.20.4/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.20 && \
-    chmod +x /usr/local/bin/* && \
+    chmod +x /usr/local/bin/kubectl* && \
     ln -s /usr/local/bin/kubectl-1.19 /usr/local/bin/kubectl && \
     mkdir /root/.kube
 


### PR DESCRIPTION
This PR adds the Rancher log collector script into the image which gets pulled from master at build time.

This is needed as part of automating the log collection process as part of https://github.com/rancherlabs/support-tools/pull/99